### PR TITLE
AlertMagic body template: Correct typo in property name

### DIFF
--- a/alertmagic/body.liquid
+++ b/alertmagic/body.liquid
@@ -19,5 +19,5 @@
   "organizationId": "{{organizationId}}",
   "organizationName": "{{organizationName}}",
   "organizationUrl": "{{organizationUrl}}",
-  "sentAd": "{{sentAt}}"
+  "sentAt": "{{sentAt}}"
 }


### PR DESCRIPTION
We have an inconsistency in our templates; the readme calls the Sent At property one thing - a valid property name of sentAt - but body.liquid shows the property name as something else - sentAd, which is a typo. This has caused a few problems for people, so we would be grateful if you could merge this fix to make things consistent, and avoid these future issues.